### PR TITLE
Update “Doncaster Metropolitan Borough” to “City of Doncaster”

### DIFF
--- a/data/source/local-authority-info.json
+++ b/data/source/local-authority-info.json
@@ -7251,7 +7251,7 @@
     },
     {
         "local-authority-code": "DNC",
-        "official-name": "Doncaster Metropolitan Borough Council",
+        "official-name": "City of Doncaster Council",
         "nice-name": "Doncaster",
         "gss-code": "E08000017",
         "start-date": "1974-04-01",
@@ -7266,7 +7266,11 @@
             "Doncaster",
             "doncaster",
             "doncaster district",
-            "doncaster metropolitan borough council"
+            "doncaster metropolitan borough council",
+            "city of doncaster council",
+            "city of doncaster",
+            "doncaster city council",
+            "doncaster city"
         ],
         "former-gss-codes": [],
         "notes": ""


### PR DESCRIPTION
Doncaster gained City status in November 2022, and the metropolitan borough council has aparently referred to itself as "City of Doncaster Council" since then:

https://www.doncaster.gov.uk/services/get-involved/show-your-support-for-the-doncaster-city-bid

> City of Doncaster has been confirmed as the borough’s new name at a Full Council meeting held on 17 November 2022.

The name change was presented as Agenda Item 4:

https://doncaster.moderngov.co.uk/documents/g4393/Public%20reports%20pack%2017th-Nov-2022%2015.10%20Council.pdf?T=10