### PR TITLE
add alt name for KHL

### DIFF
--- a/data/source/local-authority-info.json
+++ b/data/source/local-authority-info.json
@@ -5759,7 +5759,8 @@
             "kingston upon hull",
             "kingston upon hull city of",
             "kingston upon hull, city of",
-            "kingston-upon-hull city council"
+            "kingston-upon-hull city council",
+            "kingston-upon-hull"
         ],
         "former-gss-codes": [],
         "notes": ""


### PR DESCRIPTION
Our LGBCE scraper fuzzy matches the local authority slugs on the LGBCE site to their registry codes using the `lookup_name_to_registry` csv.

We've got >95% fuzzy match cutoff and Hull City Council is being thrown out because the closest fuzzy match to their LGBCE slug `kingston-upon-hull` is `kingston-upon-hull city council` with 90%. 

So I've suggested adding just `kingston-upon-hull` as an alternative name.